### PR TITLE
Parameterize Zig build system

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2,12 +2,17 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{ .preferred_optimize_mode = .ReleaseFast });
+    const strip = b.option(bool, "strip", "Whether to strip symbols from the binary, defaults to false") orelse false;
 
     // Create the executable
     const bin = b.addExecutable(.{
         .name = "dsv2",
         .target = target,
-        .optimize = .ReleaseFast,
+        // uses libc
+        .link_libc = true,
+        .optimize = optimize,
+        .strip = strip,
     });
 
     // Add C source files
@@ -26,12 +31,12 @@ pub fn build(b: *std.Build) void {
             "src/util.c",
         },
         .flags = &.{
-            "-std=c99",
-            "-O3",
+            "-std=c89",
+            "-Wall",
+            "-Wextra",
+            "-Wpedantic",
+            "-Werror",
         },
     });
-
-    // Link libc
-    bin.linkLibC();
     b.installArtifact(bin);
 }

--- a/src/dsv_internal.h
+++ b/src/dsv_internal.h
@@ -26,9 +26,6 @@ extern "C" {
 #include <stdarg.h>
 #include <limits.h>
 
-/* required because snprintf isn't strictly c89. no `restrict', that's not c89 either */
-int snprintf(char *, size_t, const char *, ...);
-
 #include "dsv.h"
 
 /* subsections of the encoded data */

--- a/src/dsv_internal.h
+++ b/src/dsv_internal.h
@@ -26,6 +26,9 @@ extern "C" {
 #include <stdarg.h>
 #include <limits.h>
 
+/* required because snprintf isn't strictly c89. no `restrict', that's not c89 either */
+int snprintf(char *, size_t, const char *, ...);
+
 #include "dsv.h"
 
 /* subsections of the encoded data */

--- a/src/dsv_main.c
+++ b/src/dsv_main.c
@@ -376,7 +376,10 @@ get_param(char *argv)
     for (i = 0; params[i].prefix != NULL; i++) {
         struct PARAM *par = &params[i];
         char buf[512];
-        snprintf(buf, sizeof(buf) - 1, "%s=", par->prefix);
+        if (strlen(par->prefix) >= sizeof(buf) - 2) continue;
+
+        sprintf(buf, "%s=", par->prefix);
+
         if (!prefixcmp(buf, &p)) {
             continue;
         }


### PR DESCRIPTION
- add `optimize` parameter
- add `strip` parameter
- add warnings
- remove `-O3` that would be overwritten by optimize mode
- use C89 with snprintf instead of C99