### PR TITLE
Add an Asymmetrical Subband Filter

### DIFF
--- a/src/dsv.h
+++ b/src/dsv.h
@@ -32,7 +32,7 @@ extern "C" {
 #define DSV_FOURCC_1     'S'
 #define DSV_FOURCC_2     'V'
 #define DSV_FOURCC_3     '2'
-#define DSV_VERSION_MINOR 0
+#define DSV_VERSION_MINOR 1
 
 /* B.1.1 Packet Type */
 #define DSV_PT_META 0x00

--- a/src/dsv_encoder.c
+++ b/src/dsv_encoder.c
@@ -197,6 +197,12 @@ quality2quant(DSV_ENCODER *enc, DSV_ENCDATA *d)
         q = enc->quality;
         enc->rc_qual = q;
     }
+    /* give a bit less quality to I frames to try to spread bits more evenly. */
+    if (!d->params.has_ref && d->fnum > 0) {
+        q -= q / 16;
+
+        q = CLAMP(q, enc->min_I_frame_quality, enc->max_quality);
+    }
     d->quant = qual_to_qp(q);
 
     DSV_DEBUG(("frame quant = %d from %d", d->quant, q));

--- a/src/dsv_encoder.h
+++ b/src/dsv_encoder.h
@@ -23,7 +23,7 @@ extern "C" {
 
 #include "dsv_internal.h"
 
-#define DSV_ENCODER_VERSION 2
+#define DSV_ENCODER_VERSION 3
 
 #define DSV_GOP_INTRA 0
 #define DSV_GOP_INF   INT_MAX

--- a/src/hzcc.c
+++ b/src/hzcc.c
@@ -29,7 +29,7 @@
 #define MINQP    4
 #define MINQUANT (1 << MINQP)  /* C.2 MINQUANT */
 
-#define QP_I     4
+#define QP_I     3
 #define QP_P     3
 
 #define RUN_BITS 24


### PR DESCRIPTION
Adding a new subband filter (which I'm calling ASF93 for reasons explained below) for increased intra frame decoding performance.
This filter will either be optional (an alternative) or replace the current L1 filter, currently undecided.

This new filter is only applied to level 1 (to create the highest frequency subbands). It is asymmetrical and does not allow for perfect reconstruction.

Subband filtering consists of a FIR filter bank that splits up a signal into different subbands. Wavelets and the Haar transform are all special cases of subband filters.
In subband filtering, the forward transform is called 'analysis' and the inverse transform is called 'synthesis.'

With ASF93, the analysis filters are 9-tap filters. The FIR coefficients were tuned to my personal psychovisual tastes (slightly emphasized low pass features, noisy/ringy but localized high pass features). The synthesis FIR filter coefficients are the standard 3-tap filters used elsewhere in DSV2. The name ASF93 stands for "asymmetric subband filter with 9-tap analysis and 3-tap synthesis."

Reference for the idea:
_Subband image coding with three-tap pyramids by
E H Adelson and E P Simoncelli (1990)_

Strangely, I haven't been able to find anything else regarding this concept of asymmetrical subband filtering besides this paper, which is unfortunate. I believe there is some untapped potential here. I hope this update to DSV2 will help push this effort forward as well as provide a modern use-case.